### PR TITLE
feat: Dark/Light Theme Toggle (closes #20)

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}SeaClip Lite{% endblock %}</title>
+  <script>
+    // Apply theme before render to avoid flash
+    (function() {
+      var theme = localStorage.getItem('seaclip-theme') || 'dark';
+      if (theme === 'dark') {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+    })();
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -11,16 +22,92 @@
       theme: {
         extend: {
           colors: {
-            bg: '#0d1117', 'bg-alt': '#161b22', surface: '#1c2333',
-            border: '#30363d', 'border-hover': '#484f58',
-            'text-primary': '#e6edf3', 'text-secondary': '#8b949e', 'text-muted': '#7d8590',
-            primary: '#2f81f7', 'primary-hover': '#388bfd',
-            success: '#3fb950', error: '#f85149', warning: '#d29922',
+            bg: 'var(--color-bg)',
+            'bg-alt': 'var(--color-bg-alt)',
+            surface: 'var(--color-surface)',
+            border: 'var(--color-border)',
+            'border-hover': 'var(--color-border-hover)',
+            'text-primary': 'var(--color-text-primary)',
+            'text-secondary': 'var(--color-text-secondary)',
+            'text-muted': 'var(--color-text-muted)',
+            primary: '#2f81f7',
+            'primary-hover': '#388bfd',
+            success: '#3fb950',
+            error: '#f85149',
+            warning: '#d29922',
           }
         }
       }
     }
   </script>
+  <style>
+    /* Dark theme (default) */
+    :root,
+    html.dark {
+      --color-bg: #0d1117;
+      --color-bg-alt: #161b22;
+      --color-surface: #1c2333;
+      --color-border: #30363d;
+      --color-border-hover: #484f58;
+      --color-text-primary: #e6edf3;
+      --color-text-secondary: #8b949e;
+      --color-text-muted: #7d8590;
+      --scrollbar-track: #161b22;
+      --scrollbar-thumb: #30363d;
+      --md-code-bg: #161b22;
+      --md-code-color: #79c0ff;
+      --md-pre-color: #e6edf3;
+      --md-th-bg: #161b22;
+    }
+
+    /* Light theme */
+    html:not(.dark) {
+      --color-bg: #f6f8fa;
+      --color-bg-alt: #ffffff;
+      --color-surface: #eaeef2;
+      --color-border: #d0d7de;
+      --color-border-hover: #afb8c1;
+      --color-text-primary: #1f2328;
+      --color-text-secondary: #57606a;
+      --color-text-muted: #6e7781;
+      --scrollbar-track: #f6f8fa;
+      --scrollbar-thumb: #d0d7de;
+      --md-code-bg: #eaeef2;
+      --md-code-color: #0550ae;
+      --md-pre-color: #1f2328;
+      --md-th-bg: #eaeef2;
+    }
+
+    body { background: var(--color-bg); color: var(--color-text-primary); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+    ::-webkit-scrollbar { width: 6px; }
+    ::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+    ::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); }
+    .glow-active { box-shadow: 0 0 12px rgba(47, 129, 247, 0.4); border-color: #2f81f7; }
+    .glow-error { box-shadow: 0 0 12px rgba(248, 81, 73, 0.4); border-color: #f85149; }
+    .badge { display: inline-flex; align-items: center; padding: 2px 8px; font-size: 11px; font-weight: 600; }
+    .htmx-indicator { opacity: 0; transition: opacity 200ms; }
+    .htmx-request .htmx-indicator { opacity: 1; }
+    @keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+    .pulse-dot { animation: pulse-dot 1.5s ease-in-out infinite; }
+    .md-body h1, .md-body h2, .md-body h3 { color: var(--color-text-primary); font-weight: 600; margin: 0.75em 0 0.4em; }
+    .md-body h1 { font-size: 1.2em; }
+    .md-body h2 { font-size: 1.05em; border-bottom: 1px solid var(--color-border); padding-bottom: 4px; }
+    .md-body h3 { font-size: 0.95em; }
+    .md-body p { margin: 0 0 6px; }
+    .md-body code { background: var(--md-code-bg); color: var(--md-code-color); padding: 1px 5px; border-radius: 4px; font-family: 'SF Mono', Consolas, monospace; font-size: 0.9em; }
+    .md-body pre { background: var(--md-code-bg); border: 1px solid var(--color-border); padding: 12px; overflow-x: auto; border-radius: 4px; margin: 6px 0; }
+    .md-body pre code { background: none; color: var(--md-pre-color); padding: 0; font-size: 11px; }
+    .md-body table { width: 100%; border-collapse: collapse; font-size: 11px; margin: 6px 0; }
+    .md-body th, .md-body td { border: 1px solid var(--color-border); padding: 6px 10px; }
+    .md-body th { background: var(--md-th-bg); color: var(--color-text-secondary); text-align: left; }
+    .md-body ul { padding-left: 1.25rem; list-style: disc; margin: 4px 0; }
+    .md-body ol { padding-left: 1.25rem; list-style: decimal; margin: 4px 0; }
+    .md-body li { margin: 2px 0; }
+    .md-body blockquote { border-left: 3px solid var(--color-border); padding-left: 12px; color: var(--color-text-secondary); margin: 6px 0; }
+    .md-body a { color: #2f81f7; text-decoration: none; }
+    .md-body a:hover { color: #388bfd; text-decoration: underline; }
+    .md-body hr { border: none; border-top: 1px solid var(--color-border); margin: 8px 0; }
+  </style>
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
   <script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked@9/marked.min.js"></script>
@@ -30,37 +117,6 @@
       marked.setOptions({ breaks: true, gfm: true });
     }
   </script>
-  <style>
-    body { background: #0d1117; color: #e6edf3; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
-    ::-webkit-scrollbar { width: 6px; }
-    ::-webkit-scrollbar-track { background: #161b22; }
-    ::-webkit-scrollbar-thumb { background: #30363d; }
-    .glow-active { box-shadow: 0 0 12px rgba(47, 129, 247, 0.4); border-color: #2f81f7; }
-    .glow-error { box-shadow: 0 0 12px rgba(248, 81, 73, 0.4); border-color: #f85149; }
-    .badge { display: inline-flex; align-items: center; padding: 2px 8px; font-size: 11px; font-weight: 600; }
-    .htmx-indicator { opacity: 0; transition: opacity 200ms; }
-    .htmx-request .htmx-indicator { opacity: 1; }
-    @keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-    .pulse-dot { animation: pulse-dot 1.5s ease-in-out infinite; }
-    .md-body h1, .md-body h2, .md-body h3 { color: #e6edf3; font-weight: 600; margin: 0.75em 0 0.4em; }
-    .md-body h1 { font-size: 1.2em; }
-    .md-body h2 { font-size: 1.05em; border-bottom: 1px solid #30363d; padding-bottom: 4px; }
-    .md-body h3 { font-size: 0.95em; }
-    .md-body p { margin: 0 0 6px; }
-    .md-body code { background: #161b22; color: #79c0ff; padding: 1px 5px; border-radius: 4px; font-family: 'SF Mono', Consolas, monospace; font-size: 0.9em; }
-    .md-body pre { background: #161b22; border: 1px solid #30363d; padding: 12px; overflow-x: auto; border-radius: 4px; margin: 6px 0; }
-    .md-body pre code { background: none; color: #e6edf3; padding: 0; font-size: 11px; }
-    .md-body table { width: 100%; border-collapse: collapse; font-size: 11px; margin: 6px 0; }
-    .md-body th, .md-body td { border: 1px solid #30363d; padding: 6px 10px; }
-    .md-body th { background: #161b22; color: #8b949e; text-align: left; }
-    .md-body ul { padding-left: 1.25rem; list-style: disc; margin: 4px 0; }
-    .md-body ol { padding-left: 1.25rem; list-style: decimal; margin: 4px 0; }
-    .md-body li { margin: 2px 0; }
-    .md-body blockquote { border-left: 3px solid #30363d; padding-left: 12px; color: #8b949e; margin: 6px 0; }
-    .md-body a { color: #2f81f7; text-decoration: none; }
-    .md-body a:hover { color: #388bfd; text-decoration: underline; }
-    .md-body hr { border: none; border-top: 1px solid #30363d; margin: 8px 0; }
-  </style>
 </head>
 <body class="min-h-screen flex">
   <!-- Sidebar -->
@@ -76,7 +132,16 @@
       <span class="text-[10px] font-semibold uppercase tracking-wider text-text-muted px-3">Resources</span>
     </div>
     <a href="http://localhost:9090/docs" target="_blank" class="sidebar-link text-text-secondary hover:text-text-primary hover:bg-surface/50 px-3 py-2 text-[13px] mb-1 transition-colors flex items-center gap-2">Docs <span class="text-[9px] text-text-muted">↗</span></a>
-    <div class="mt-auto text-[10px] text-text-muted px-2">Port 5200 · FastAPI + HTMX</div>
+
+    <!-- Theme Toggle -->
+    <div class="mt-auto">
+      <button id="theme-toggle" onclick="toggleTheme()"
+        class="w-full flex items-center gap-2 px-3 py-2 text-[13px] text-text-secondary hover:text-text-primary hover:bg-surface/50 transition-colors border-t border-border pt-3">
+        <span id="theme-icon" class="text-base leading-none">☀️</span>
+        <span id="theme-label">Light mode</span>
+      </button>
+      <div class="text-[10px] text-text-muted px-2 pt-2">Port 5200 · FastAPI + HTMX</div>
+    </div>
   </nav>
 
   <!-- Main -->
@@ -88,5 +153,31 @@
 
   <!-- Toast container -->
   <div id="toast-container" class="fixed bottom-4 right-4 flex flex-col gap-2 z-50"></div>
+
+  <script>
+    function toggleTheme() {
+      var html = document.documentElement;
+      var isDark = html.classList.contains('dark');
+      if (isDark) {
+        html.classList.remove('dark');
+        localStorage.setItem('seaclip-theme', 'light');
+      } else {
+        html.classList.add('dark');
+        localStorage.setItem('seaclip-theme', 'dark');
+      }
+      updateThemeButton();
+    }
+
+    function updateThemeButton() {
+      var isDark = document.documentElement.classList.contains('dark');
+      var icon = document.getElementById('theme-icon');
+      var label = document.getElementById('theme-label');
+      if (icon) icon.textContent = isDark ? '☀️' : '🌙';
+      if (label) label.textContent = isDark ? 'Light mode' : 'Dark mode';
+    }
+
+    // Set initial button state after DOM ready
+    document.addEventListener('DOMContentLoaded', updateThemeButton);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Add CSS custom properties (`--color-*`) for dark (default) and light themes in `base.html`
- Replace hardcoded hex colors in Tailwind config with `var(--color-*)` references
- Add theme toggle button at bottom of sidebar with sun/moon icon
- Persist preference in `localStorage` under key `seaclip-theme`
- Apply saved theme before first paint to prevent flash of wrong theme
- Light theme uses GitHub-style palette for proper daytime contrast

## Changes

**`app/templates/base.html`**
- Inline JS at `<head>` reads `localStorage` and applies `dark` class before render
- `:root` / `html.dark` CSS variable blocks define all theme colors
- `html:not(.dark)` overrides provide light-mode palette
- Tailwind custom color values updated to reference CSS vars
- Sidebar: theme toggle button appended above footer line, toggles class + localStorage

## Test plan

- [ ] Open app — dark theme loads by default (no flash)
- [ ] Click "Light mode" button in sidebar — page switches to light theme
- [ ] Refresh — light theme persists
- [ ] Click "Dark mode" button — returns to dark theme, persists on refresh
- [ ] Verify all pages (Dashboard, Kanban, Identify, Agents, Roadmap, Backup) render correctly in both themes

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)